### PR TITLE
Fix wrong header for acronyms

### DIFF
--- a/master.tex
+++ b/master.tex
@@ -68,12 +68,14 @@
 
 % 	Abkürzungsverzeichnis (siehe Datei acronyms.tex!)
 \input{acronyms}
+\ohead{Acronyms} % Neue Header-Definition
 
 %--------------------------------
 % Start des Textteils der Arbeit
 %--------------------------------
 \clearpage
-\ihead{\chaptername~\thechapter} % Neue Header-Definition
+\ihead{\chaptername~\thechapter} % Neue Header-Definition (inner header)
+\ohead{\headmark} % Neue Header-Definition (outer header)
 \pagenumbering{arabic}  % Arabische Seitenzahlen
 
 %	Anleitungs-Datei anleitung.tex einziehen. Auf diese Weise sollten Sie versuchen, für jedes einzelne


### PR DESCRIPTION
Bei Akronymen über mehr als eine Seite wurde als Header der Header der vorherigen Seiten übernommen (z.B. List of Tables oder Listings). 
Dieser Commit schreibt manuell "Acronyms" in den Header.