### PR TITLE
Fixed bug in headline before bibliography

### DIFF
--- a/master.tex
+++ b/master.tex
@@ -83,7 +83,6 @@
 \input{anleitung}
 
 %	Literaturverzeichnis
-\ihead{} % Neue Header-Definition
 \printbibliography[title=Literaturverzeichnis]
 \cleardoublepage
 


### PR DESCRIPTION
The last page directly before the bibliography doesn't had an inner headline (e.g. "Chapter 1"). This seem to be caused by \ihead{} directly before \printbibliography.