### PR TITLE
fix bug in bibliography headline

### DIFF
--- a/master.tex
+++ b/master.tex
@@ -83,6 +83,8 @@
 \input{anleitung}
 
 %	Literaturverzeichnis
+\clearpage
+\ihead{}
 \printbibliography[title=Literaturverzeichnis]
 \cleardoublepage
 


### PR DESCRIPTION
My bug-fixing in #2 created another bug. Removing `\ihead{}` before `\printbibliography` has resulted in the inner heading of the bibliography being not empty but that of the last chapter. This can only be noticed if the bibliography extends over several pages.

To fix this problem, I have added the command `\ihead{}` again and added a `\clearpage` before it.
The `\ihead{}` ensures that there is no inner heading in the bibliography and the `\clearpage` ensures that the chapter heading remains on the last page of the chapter.

I've tested it with a longer bibliography locally where everything works as expected.